### PR TITLE
FFS-2224 Aktiver sporing og JSON-logging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,9 @@ dependencies {
     implementation("org.flywaydb:flyway-database-postgresql")
     runtimeOnly("org.postgresql:postgresql")
 
-    implementation("no.novari:flyt-web-instance-gateway:3.0.0")
+    implementation("no.novari:flyt-web-instance-gateway:3.1.0-rc-3")
     implementation("no.novari:flyt-cache:3.0.0")
+    implementation("no.novari:telemetry-starter:0.0.3")
 
     implementation("no.novari:fint-model-resource:$fintModelResourceVersion")
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
 
     implementation("no.novari:flyt-web-instance-gateway:3.1.0-rc-3")
     implementation("no.novari:flyt-cache:3.0.0")
-    implementation("no.novari:telemetry-starter:0.0.3")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     implementation("no.novari:fint-model-resource:$fintModelResourceVersion")
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -48,7 +48,7 @@ dependencies {
 
     implementation("no.novari:flyt-web-instance-gateway:3.1.0-rc-3")
     implementation("no.novari:flyt-cache:3.0.0")
-    implementation("no.novari:telemetry-starter:0.0.4")
+    implementation("no.novari:telemetry-starter:0.0.5")
 
     implementation("no.novari:fint-model-resource:$fintModelResourceVersion")
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.dispatch.base-url
           value: "https://vigoiks.service-now.com/api/now/table"
       - op: add

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.dispatch.base-url
           value: "https://vigoiks.service-now.com/api/now/table"
       - op: add

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -32,11 +32,6 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
-          name: server.servlet.context-path
-          value: "/beta"
-      - op: add
-        path: "/spec/env/-"
-        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add
@@ -44,6 +39,11 @@ patches:
         value:
           name: novari.flyt.egrunnerverv.checkSaksbehandler
           value: "false"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: server.servlet.context-path
+          value: "/beta"
       - op: replace
         path: "/spec/probes/startup/path"
         value: "/beta/actuator/health"
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-egrunnerverv-gateway

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -32,6 +32,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -32,6 +32,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkEmailDomain
           value: "false"
       - op: add

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -32,11 +32,6 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
-          name: server.servlet.context-path
-          value: "/beta"
-      - op: add
-        path: "/spec/env/-"
-        value:
           name: novari.flyt.egrunnerverv.checkEmailDomain
           value: "false"
       - op: add
@@ -49,6 +44,11 @@ patches:
         value:
           name: novari.flyt.egrunnerverv.dispatch.token-uri
           value: "https://vigoiks.service-now.com/oauth_token.do"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: server.servlet.context-path
+          value: "/beta"
       - op: replace
         path: "/spec/probes/startup/path"
         value: "/beta/actuator/health"
@@ -61,6 +61,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-egrunnerverv-gateway

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.dispatch.base-url
           value: "https://vigoiks.service-now.com/api/now/table"
       - op: add

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.dispatch.base-url
           value: "https://vigoiks.service-now.com/api/now/table"
       - op: add

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -46,6 +46,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-egrunnerverv-gateway

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -32,6 +32,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: server.servlet.context-path
           value: "/beta"
       - op: replace

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -32,6 +32,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -32,11 +32,6 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
-          name: server.servlet.context-path
-          value: "/beta"
-      - op: add
-        path: "/spec/env/-"
-        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add
@@ -44,6 +39,11 @@ patches:
         value:
           name: novari.flyt.egrunnerverv.checkSaksbehandler
           value: "false"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: server.servlet.context-path
+          value: "/beta"
       - op: replace
         path: "/spec/probes/startup/path"
         value: "/beta/actuator/health"
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-egrunnerverv-gateway

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -32,11 +32,6 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
-          name: server.servlet.context-path
-          value: "/beta"
-      - op: add
-        path: "/spec/env/-"
-        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add
@@ -44,6 +39,11 @@ patches:
         value:
           name: novari.flyt.egrunnerverv.checkSaksbehandler
           value: "false"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: server.servlet.context-path
+          value: "/beta"
       - op: replace
         path: "/spec/probes/startup/path"
         value: "/beta/actuator/health"
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-egrunnerverv-gateway

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -32,6 +32,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -29,6 +29,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.dispatch.base-url
           value: "https://vigoiks.service-now.com/api/now/table"
       - op: add

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -32,11 +32,6 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
-          name: server.servlet.context-path
-          value: "/beta"
-      - op: add
-        path: "/spec/env/-"
-        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add
@@ -44,6 +39,11 @@ patches:
         value:
           name: novari.flyt.egrunnerverv.checkSaksbehandler
           value: "false"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: server.servlet.context-path
+          value: "/beta"
       - op: replace
         path: "/spec/probes/startup/path"
         value: "/beta/actuator/health"
@@ -56,6 +56,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "/beta/actuator/prometheus"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-egrunnerverv-gateway

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -32,6 +32,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: novari.flyt.egrunnerverv.checkSaksansvarligEpost
           value: "false"
       - op: add

--- a/kustomize/templates/overlay-beta.yaml.tpl
+++ b/kustomize/templates/overlay-beta.yaml.tpl
@@ -28,7 +28,12 @@ patches:
         path: "/spec/env/-"
         value:
           name: novari.kafka.topic.org-id
-          value: "$NAMESPACE"$ENV_PATCHES$DISPATCH_PATCHES
+          value: "$NAMESPACE"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "$ORG_ID"$ENV_PATCHES$DISPATCH_PATCHES
       - op: add
         path: "/spec/env/-"
         value:

--- a/kustomize/templates/overlay-beta.yaml.tpl
+++ b/kustomize/templates/overlay-beta.yaml.tpl
@@ -46,6 +46,11 @@ patches:
       - op: replace
         path: "/spec/observability/metrics/path"
         value: "$METRICS_PATH"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
     target:
       kind: Application
       name: fint-flyt-egrunnerverv-gateway

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -25,7 +25,12 @@ patches:
         path: "/spec/env/-"
         value:
           name: novari.kafka.topic.org-id
-          value: "$NAMESPACE"$ENV_PATCHES$DISPATCH_PATCHES
+          value: "$NAMESPACE"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "novari.telemetry.org-id"
+          value: "$ORG_ID"$ENV_PATCHES$DISPATCH_PATCHES
       - op: replace
         path: "/spec/probes/startup/path"
         value: "$STARTUP_PATH"

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,6 +27,8 @@ server:
     max-swallow-size: 100MB
 
 spring:
+  application:
+    name: ${fint.application-id}
   profiles:
     include:
       - flyt-kafka

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Sammendrag

- Legger til `telemetry-starter` for HTTP-selvinstrumentering
- Bumper `flyt-web-instance-gateway` til versjon med Kafka-sporing (`novari.kafka.tracing.enabled=true`) og korrekt trace-propagering
- Kobler inn telemetry-starter sitt JSON-loggfragment - `logstash-logback-encoder` lå allerede som avhengighet, men uten aktiv logback-config - slik at `traceId`/`spanId` blir søkbare i loggene

Del av OpenTelemetry-tracing-epicen (FFS-2196), jf. rettet beslutning 13 i løsningsanalysen (Kafka-sporing skal på i alle utrullinger, ikke bare instance-service).