### PR TITLE
Bytt til io.github.ben-manes.versions plugin-id

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@ buildscript {
 plugins {
     id("org.springframework.boot") version "3.5.16"
     id("io.spring.dependency-management") version "1.1.7"
-    id("com.github.ben-manes.versions") version "0.61.0"
+    id("io.github.ben-manes.versions") version "0.61.0"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     jacoco
     kotlin("jvm") version "2.4.10"


### PR DESCRIPTION
## Sammendrag

Plugin-ID-en `com.github.ben-manes.versions` er deprecated og logger advarsel ved bygg:

> The com.github.ben-manes.versions plugin id is deprecated; apply io.github.ben-manes.versions instead.

Fra og med 0.55.0 heter plugin-en `io.github.ben-manes.versions`, i tråd med Gradle Plugin Portal sin namespace-policy for `com.github.*`.

Samme artefakt betjener begge ID-ene, så versjonen står uendret på 0.61.0, og `import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask` trenger ingen endring — kun plugin-descriptoren i jar-en er ny.
